### PR TITLE
height for slider on various media  + some grid improvement for different media queries

### DIFF
--- a/template-artist.php
+++ b/template-artist.php
@@ -258,12 +258,14 @@ if($content.hasOverflow()) {
                 <span class="glyphicon glyphicon-menu-down"></span>
               </button>
             </div>
+            <div class="clearfix visible-sm-block visible-md-block"></div>
+
             <? else: endif;?>
 
       <!-- Events -->
       <? query_posts('cat=1&meta_key=related_artist&meta_value='.$pid.'&orderby=date&order=DESC&showposts=-1');
       if (have_posts()) : ?>
-      <div class="col-sm-5 col-md-6 col-lg-4">
+      <div class="col-sm-5 col-md-5 col-lg-4">
         <h4>Events</h4>
         <div class="artist-events">
         <? while (have_posts()) : the_post(); ?>


### PR DESCRIPTION
Haitham, to be fair, it seems to me that there would be no 100% working
solution if we want to have fixed height for each image in the
container. For now I found one which makes the whole thing look more or
less coherent. The main problem is because images have different width
and the container has fixed height, the slider somehow calculates the
proper with for each image for the size of the container we provide, it
means that some images would have blank white strips from both sides
and it will sometimes appear that the numbers with is bigger than the
with of the images, and numbers can’t respond on this, even if they
could they would be always jumping around as mad each time person
pushes a number. One thing we might use is „adaptive height” for small
screens, which would mean that all of the images will have the width of
the screen, but the height will change for images with different aspect
ratios (like with that 18th image by Jumana Manna), and numbers will
travel up and down depending on what is the image’s height. Also one of
my usability recommendations would be - on small screens (smart phones
and tablets) people usually don’t click buttons but prefer to swipe. so
maybe there is not such a big need in those numbers what so ever? think
about that, i can make this slider to make proper finger swiping if
you’ll decide so, and we may leave simple dot’s as indicators.  if you
want i can illustrate how the thing with adaptive height would work.
just tell

Some Grids Improvement: 
still they aren’t perfect, because of the arrow mostly, i meant because
the content might collapse and expanded they start jumping all around
as crazy.
